### PR TITLE
Create addon (& dummy app) skeleton 4 adapters/serializers/models

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -5,5 +5,6 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false
+  "disableAnalytics": false,
+  "port": 4233
 }

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+.env

--- a/addon/initializers/ember-data-twitch.js
+++ b/addon/initializers/ember-data-twitch.js
@@ -1,0 +1,19 @@
+import TwitchAdapter from '../adapters/twitch';
+import TwitchSerializer from '../serializers/twitch';
+
+
+export function initialize(/* application */) {
+
+  // Support initializer signature from before 2.1.0
+  // See http://emberjs.com/deprecations/v2.x/#toc_initializer-arity
+  const application = arguments[1] || arguments[0];
+
+  application.register('adapter:-twitch', TwitchAdapter);
+  application.register('serializer:-twitch', TwitchSerializer);
+}
+
+export default {
+  before: 'ember-data',
+  name: 'ember-data-twitch',
+  initialize
+};

--- a/addon/models/twitch-block.js
+++ b/addon/models/twitch-block.js
@@ -1,0 +1,7 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+
+});

--- a/addon/models/twitch-channel-feed.js
+++ b/addon/models/twitch-channel-feed.js
@@ -1,0 +1,7 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+
+});

--- a/addon/models/twitch-channel.js
+++ b/addon/models/twitch-channel.js
@@ -1,0 +1,7 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+
+});

--- a/addon/models/twitch-chat.js
+++ b/addon/models/twitch-chat.js
@@ -1,0 +1,7 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+
+});

--- a/addon/models/twitch-follow.js
+++ b/addon/models/twitch-follow.js
@@ -1,0 +1,7 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+
+});

--- a/addon/models/twitch-game.js
+++ b/addon/models/twitch-game.js
@@ -1,0 +1,7 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+
+});

--- a/addon/models/twitch-ingest.js
+++ b/addon/models/twitch-ingest.js
@@ -1,0 +1,7 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+
+});

--- a/addon/models/twitch-stream.js
+++ b/addon/models/twitch-stream.js
@@ -1,0 +1,7 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+
+});

--- a/addon/models/twitch-subscription.js
+++ b/addon/models/twitch-subscription.js
@@ -1,0 +1,7 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+
+});

--- a/addon/models/twitch-team.js
+++ b/addon/models/twitch-team.js
@@ -1,0 +1,7 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+
+});

--- a/addon/models/twitch-user.js
+++ b/addon/models/twitch-user.js
@@ -1,0 +1,7 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+
+});

--- a/addon/models/twitch-video.js
+++ b/addon/models/twitch-video.js
@@ -1,0 +1,6 @@
+import Model from 'ember-data/model';
+// import attr from 'ember-data/attr';
+// import { belongsTo, hasMany } from 'ember-data/relationships';
+
+export default Model.extend({
+});

--- a/addon/serializers/twitch.js
+++ b/addon/serializers/twitch.js
@@ -1,0 +1,4 @@
+import JSONAPISerializer from 'ember-data/serializers/json-api';
+
+export default JSONAPISerializer.extend({
+});

--- a/app/initializers/ember-data-twitch.js
+++ b/app/initializers/ember-data-twitch.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/initializers/ember-data-twitch';

--- a/app/models/twitch-block.js
+++ b/app/models/twitch-block.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-block';

--- a/app/models/twitch-channel-feed.js
+++ b/app/models/twitch-channel-feed.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-channel-feed';

--- a/app/models/twitch-channel.js
+++ b/app/models/twitch-channel.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-channel';

--- a/app/models/twitch-chat.js
+++ b/app/models/twitch-chat.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-chat';

--- a/app/models/twitch-follow.js
+++ b/app/models/twitch-follow.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-follow';

--- a/app/models/twitch-game.js
+++ b/app/models/twitch-game.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-game';

--- a/app/models/twitch-ingest.js
+++ b/app/models/twitch-ingest.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-ingest';

--- a/app/models/twitch-search.js
+++ b/app/models/twitch-search.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-search';

--- a/app/models/twitch-stream.js
+++ b/app/models/twitch-stream.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-stream';

--- a/app/models/twitch-subscription.js
+++ b/app/models/twitch-subscription.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-subscription';

--- a/app/models/twitch-team.js
+++ b/app/models/twitch-team.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-team';

--- a/app/models/twitch-user.js
+++ b/app/models/twitch-user.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-user';

--- a/app/models/twitch-video.js
+++ b/app/models/twitch-video.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/models/twitch-video';

--- a/app/serializers/twitch.js
+++ b/app/serializers/twitch.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch';

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-data-twitch",
   "dependencies": {
-    "ember": "~2.7.0-beta.3",
+    "ember": "~2.7.0",
     "ember-cli-shims": "0.1.1",
     "ember-qunit-notifications": "0.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -21,16 +21,18 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.0.1",
-    "ember-cli": "2.7.0-beta.5",
+    "ember-cli": "2.7.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-eslint": "1.6.0",
-    "ember-cli-github-pages": "0.1.0",
+    "ember-cli-dotenv": "1.2.0",
+    "ember-cli-eslint": "1.7.0",
+    "ember-cli-github-pages": "0.1.2",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
+    "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^2.0.0",
     "ember-cli-release": "1.0.0-beta.2",
+    "ember-cli-sass": "5.3.1",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
@@ -38,7 +40,8 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "ember-welcome-page": "^1.0.1",
+    "ember-route-action-helper": "0.3.2",
+    "ember-truth-helpers": "1.2.0",
     "loader.js": "^4.0.1"
   },
   "keywords": [
@@ -48,9 +51,10 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-data": "^2.7.0-beta.1"
+    "ember-data": "^2.7.0"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://elwayman02.github.io/ember-data-twitch"
   }
 }

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,0 +1,5 @@
+import BaseTwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default BaseTwitchAdapter.extend({
+
+});

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,11 +3,9 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-let App;
-
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-App = Ember.Application.extend({
+const App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/components/menu-link-item.js
+++ b/tests/dummy/app/components/menu-link-item.js
@@ -1,0 +1,13 @@
+import Component from 'ember-component';
+import layout from '../templates/components/menu-link-item';
+
+
+export default Component.extend({
+  layout,
+  tagName: 'li',
+  classNames: ['c-menu-link-item', 'u-relative'],
+  classNameBindings: ['isActive'],
+
+  routeName: null,
+  title: null
+});

--- a/tests/dummy/app/components/x-sidenav.js
+++ b/tests/dummy/app/components/x-sidenav.js
@@ -1,0 +1,17 @@
+import Component from 'ember-component';
+import computed from 'ember-computed';
+import injectService from 'ember-service/inject';
+import layout from '../templates/components/x-sidenav';
+
+const { readOnly } = computed;
+
+
+export default Component.extend({
+  layout,
+  tagName: 'section',
+  classNames: ['c-sidenav'],
+  SidenavService: injectService('sidenav'),
+
+  activeTopLevelRoute: readOnly('SidenavService.activeTopLevelRoute'),
+  menuLinks: readOnly('SidenavService.menuLinks')
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,20 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('index', { path: '/' });
+  this.route('videos');
+  this.route('twitch-auth');
+  this.route('users');
+  this.route('teams');
+  this.route('subscriptions');
+  this.route('streams');
+  this.route('ingests');
+  this.route('searches');
+  this.route('games');
+  this.route('follows');
+  this.route('chats');
+  this.route('channels');
+  this.route('blocks');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+import injectService from 'ember-service/inject';
+
+const { Route } = Ember;
+
+
+export default Route.extend({
+  SidenavService: injectService('sidenav'),
+
+  actions: {
+    authenticate() {
+      // TODO: Implement -- here, I'm thinking it would just be calling an `authenticate`
+      // method from the addon's session service
+    },
+
+    willTransition(transition) {
+      const activeTopLevelRoute = transition.targetName.split('.')[0];
+      this.get('SidenavService').set('activeTopLevelRoute', activeTopLevelRoute);
+    }
+  }
+});

--- a/tests/dummy/app/routes/blocks.js
+++ b/tests/dummy/app/routes/blocks.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/channels.js
+++ b/tests/dummy/app/routes/channels.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/chats.js
+++ b/tests/dummy/app/routes/chats.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/follows.js
+++ b/tests/dummy/app/routes/follows.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/games.js
+++ b/tests/dummy/app/routes/games.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend({});

--- a/tests/dummy/app/routes/ingests.js
+++ b/tests/dummy/app/routes/ingests.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/searches.js
+++ b/tests/dummy/app/routes/searches.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/streams.js
+++ b/tests/dummy/app/routes/streams.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/subscriptions.js
+++ b/tests/dummy/app/routes/subscriptions.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/teams.js
+++ b/tests/dummy/app/routes/teams.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/twitch-auth.js
+++ b/tests/dummy/app/routes/twitch-auth.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import TwitchRedirectMixin from 'ember-data-twitch/mixins/twitch-redirect-handler';
+
+const { Route } = Ember;
+
+
+export default Route.extend(TwitchRedirectMixin, {
+
+});

--- a/tests/dummy/app/routes/users.js
+++ b/tests/dummy/app/routes/users.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/routes/videos.js
+++ b/tests/dummy/app/routes/videos.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model() {
+    // return this.store.findAll('twitch-video');
+    return {};
+  }
+});

--- a/tests/dummy/app/services/sidenav.js
+++ b/tests/dummy/app/services/sidenav.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+
+const { Service } = Ember;
+
+// const menuLink = EmberObject.extend({
+//   routeName: null,
+//   title: null,
+//   isActive: null,
+// })
+
+export default Service.extend({
+  activeTopLevelRoute: null,
+
+  menuLinks: [
+    { routeName: 'videos', title: 'Videos' },
+    { routeName: 'blocks', title: 'Blocks' },
+    { routeName: 'channels', title: 'Channels' },
+    { routeName: 'chats', title: 'Chats' },
+    { routeName: 'follows', title: 'Follows' },
+    { routeName: 'games', title: 'Games' },
+    { routeName: 'ingests', title: 'Ingests' },
+    { routeName: 'searches', title: 'Searches' },
+    { routeName: 'streams', title: 'Streams' },
+    { routeName: 'subscriptions', title: 'Subscriptions' },
+    { routeName: 'teams', title: 'Teams' },
+    { routeName: 'users', title: 'Users' }
+  ]
+});

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,0 +1,66 @@
+@import "variables/variables";
+
+@import "components/components";
+@import "object-patterns/object-patterns";
+@import "typography/typography";
+@import "utilities/utilities";
+
+html {
+  font-size: 100%;
+}
+
+body {
+  position: relative;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background-color: hsla(0, 0%, 92%, 1);
+}
+
+ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+
+.application {
+  position: relative;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  background-color: hsla(0, 0%, 92%, 1);
+  z-index: 1;
+  display: flex;
+  flex-wrap: nowrap;
+
+  .application__sidenav {
+    flex: 0 1 $width__sidenav;
+    box-shadow: 2px 0 3px 1px $color__box-shadow;
+    background-image: linear-gradient(
+      to bottom,
+      $theme-color__primary-1--900 0%,
+      $theme-color__primary-1--700 66%,
+      $theme-color__primary-1--500
+    );
+    z-index: 1;
+  }
+
+  .application__navbar {
+    height: $height__navbar;
+  }
+
+  .application__main-content {
+    flex: 1;
+    padding: $padding__content-box--lg;
+    padding-top: $height__navbar;
+    overflow: hidden;
+    overflow-y: auto;
+  }
+
+
+
+}

--- a/tests/dummy/app/styles/components/_button.scss
+++ b/tests/dummy/app/styles/components/_button.scss
@@ -1,0 +1,18 @@
+.c-button {
+  display: flex;
+  font-size: 1em;
+  padding: $padding__content-box;
+  border-radius: 0.125em;
+  color: $theme-color__nearWhite;
+  border: 0;
+  cursor: pointer;
+  background-color: $theme-color__primary-1--500;
+  transition-property: background-color;
+  transition-duration: 0.25s;
+  transition-timing-function: $easing__ease-out-cubic;
+
+  &:hover {
+    background-color: $theme-color__primary-1--300;
+    transition-timing-function: $easing__ease-in-quad;
+  }
+}

--- a/tests/dummy/app/styles/components/_components.scss
+++ b/tests/dummy/app/styles/components/_components.scss
@@ -1,0 +1,4 @@
+@import "button";
+@import "menu-link-item";
+@import "navbar";
+@import "sidenav";

--- a/tests/dummy/app/styles/components/_menu-link-item.scss
+++ b/tests/dummy/app/styles/components/_menu-link-item.scss
@@ -1,0 +1,34 @@
+.c-menu-link-item {
+  height: 3.25em;
+  position: relative;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    z-index: -1;
+    transition-property: opacity;
+    transition-duration: $duration__fade-toggle;
+    transition-timing-function: $easing__ease-out-cubic;
+  }
+
+  &:hover:not(.is-active)::before,
+  &:focus:not(.is-active)::before {
+    opacity: 1;
+    transition-timing-function: $easing__ease-in-quad;
+  }
+
+  &.is-active::after {
+    opacity: 1;
+  }
+
+  .c-menu-link-item__link {
+    display: flex;
+    align-items: center;
+  }
+}

--- a/tests/dummy/app/styles/components/_navbar.scss
+++ b/tests/dummy/app/styles/components/_navbar.scss
@@ -1,0 +1,27 @@
+.c-navbar {
+  background-color: white;
+  border: 1px solid $theme-color__primary-1--500;
+  box-shadow: 0 1px 3px $color__box-shadow;
+  display: flex;
+  flex-wrap: nowrap;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+
+  .c-navbar__content-section {
+    display: flex;
+    align-items: center;
+    flex-grow: 1;
+  }
+
+
+  .c-navbar__content-section {
+    flex-grow: 1;
+  }
+
+  .c-navbar__login-button {
+    margin-left: auto;
+    font-size: 0.75em;
+  }
+}

--- a/tests/dummy/app/styles/components/_sidenav.scss
+++ b/tests/dummy/app/styles/components/_sidenav.scss
@@ -1,0 +1,43 @@
+$height__sidenav-header: $height__navbar * 2.125;
+$height__sidenav-body: calc(100% - #{$height__sidenav-header});
+
+.c-sidenav {
+  overflow: hidden;
+  overflow-y: auto;
+
+  .c-sidenav__header-section {
+    height: $height__sidenav-header;
+  }
+  .c-sidenav__body-section {
+    height: $height__sidenav-body;
+  }
+
+  .c-sidenav__header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .c-sidenav__logo {
+    color: $theme-color__nearWhite;
+    font-size: 1.5em;
+    text-decoration: none;
+  }
+
+  .c-sidenav__menu-link-item {
+    color: $theme-color__nearWhite;
+  }
+
+  .c-sidenav__menu-link-item:not(.is-active):hover,
+  .c-sidenav__menu-link-item:not(.is-active):focus {
+    color: $theme-color__primary-1--300;
+  }
+
+  .c-sidenav__menu-link-item::before {
+    background-color: hsla(0, 0%, 100%, 0.73);
+  }
+
+  .c-sidenav__menu-link-item::after {
+    background-color: $theme-color__primary-1--300;
+  }
+}

--- a/tests/dummy/app/styles/object-patterns/_content-box.scss
+++ b/tests/dummy/app/styles/object-patterns/_content-box.scss
@@ -1,0 +1,4 @@
+.o-content-box {
+  box-sizing: border-box;
+  padding: $padding__content-box;
+}

--- a/tests/dummy/app/styles/object-patterns/_menu-link.scss
+++ b/tests/dummy/app/styles/object-patterns/_menu-link.scss
@@ -1,0 +1,5 @@
+.o-menu-link {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}

--- a/tests/dummy/app/styles/object-patterns/_object-patterns.scss
+++ b/tests/dummy/app/styles/object-patterns/_object-patterns.scss
@@ -1,0 +1,8 @@
+/**
+ * "Objects" (prefixed with "o-") that are meant to
+ * comprise lightweight, abstract, composable patterns
+ * @see: https://www.google.com/search?q=object+orieinted+css&oq=object+orieinted+css&aqs=chrome..69i57j0l5.3247j0j7&sourceid=chrome&ie=UTF-8
+ */
+
+@import "content-box";
+@import "menu-link";

--- a/tests/dummy/app/styles/typography/_fonts.scss
+++ b/tests/dummy/app/styles/typography/_fonts.scss
@@ -1,0 +1,21 @@
+/*
+* Target the system fonts first (http://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/)
+* then provide similar fallbacks
+*/
+
+html {
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Oxygen',
+    'Ubuntu',
+    'Cantarell',
+    'Fira Sans',
+    'Droid Sans',
+    Avenir,
+    Geneva,
+    Tahoma,
+    san-serif;
+}

--- a/tests/dummy/app/styles/typography/_headings.scss
+++ b/tests/dummy/app/styles/typography/_headings.scss
@@ -1,0 +1,5 @@
+h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+  color: $theme-color__primary-1--500;
+  line-height: 2.25;
+}

--- a/tests/dummy/app/styles/typography/_typography.scss
+++ b/tests/dummy/app/styles/typography/_typography.scss
@@ -1,0 +1,2 @@
+@import "fonts";
+@import "headings";

--- a/tests/dummy/app/styles/utilities/_utilities.scss
+++ b/tests/dummy/app/styles/utilities/_utilities.scss
@@ -1,0 +1,10 @@
+.u-relative { position: relative; }
+.u-fill-height { height: 100%; }
+.u-fill-width { width: 100%; }
+
+.u-fill {
+  height: 100%;
+  width: 100%;
+}
+
+.u-align-center { text-align: center; }

--- a/tests/dummy/app/styles/variables/_variables.scss
+++ b/tests/dummy/app/styles/variables/_variables.scss
@@ -1,0 +1,41 @@
+/**
+ * -----------------------------------------
+ * COLORS
+ * -----------------------------------------
+ */
+$theme-color__primary-1--100: hsla(261, 53%, 76%, 1.00);
+$theme-color__primary-1--300: hsla(261, 43%, 55%, 1.00);
+$theme-color__primary-1--500: hsla(261, 43%, 45%, 1.00);
+$theme-color__primary-1--700: hsla(255, 27%, 20%, 1.00);
+$theme-color__primary-1--900: hsla(256, 22%, 10%, 1.00);
+
+$theme-color__nearWhite: hsla(0, 0%, 92%, 1.00);
+
+$color__box-shadow: hsla(0, 0%, 0%, 0.43);
+
+/**
+ * -----------------------------------------
+ * ANIMATION
+ * -----------------------------------------
+ */
+$duration__fade-toggle: 0.25s;
+
+$easing__ease-in-quad: cubic-bezier(0.550, 0.085, 0.680, 0.530);
+$easing__ease-out-cubic: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+
+
+
+/**
+ * -----------------------------------------
+ * DIMENSIONS
+ * -----------------------------------------
+ */
+
+$height__navbar: 4rem;
+$width__sidenav: 18rem;
+
+/*
+ * 180:130 padding ratio to align content aspect ratio with human FOV
+ */
+$padding__content-box: 0.75em 1.05em;
+$padding__content-box--lg: 1.5em 2.10em;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,0 +1,19 @@
+<main class="application">
+
+  {{x-sidenav class="application__sidenav u-fill-height"}}
+
+  {{!-- Navbar --}}
+  <section class="application__navbar c-navbar">
+    <div class="c-navbar__content-section u-fill-height o-content-box">
+      <button class="c-button c-button--primary c-navbar__login-button" onclick={{route-action 'authenticate'}}>Authenticate with Twitch</button>
+    </div>
+  </section>
+
+  <section class="application__main-content u-fill-height">
+
+
+    {{!-- Main content --}}
+    {{outlet}}
+  </section>
+
+</main>

--- a/tests/dummy/app/templates/blocks.hbs
+++ b/tests/dummy/app/templates/blocks.hbs
@@ -1,0 +1,3 @@
+<h2>Blocks</h2>
+
+{{outlet}}

--- a/tests/dummy/app/templates/channels.hbs
+++ b/tests/dummy/app/templates/channels.hbs
@@ -1,0 +1,3 @@
+<h2>Channels</h2>
+
+{{outlet}}

--- a/tests/dummy/app/templates/chats.hbs
+++ b/tests/dummy/app/templates/chats.hbs
@@ -1,0 +1,3 @@
+<h2>Chats</h2>
+
+{{outlet}}

--- a/tests/dummy/app/templates/components/menu-link-item.hbs
+++ b/tests/dummy/app/templates/components/menu-link-item.hbs
@@ -1,0 +1,1 @@
+{{#link-to routeName class='c-menu-link-item__link o-menu-link u-fill o-content-box'}}{{title}}{{/link-to}}

--- a/tests/dummy/app/templates/components/x-sidenav.hbs
+++ b/tests/dummy/app/templates/components/x-sidenav.hbs
@@ -1,0 +1,15 @@
+<section class="c-sidenav__header-section u-relative">
+  <header class="c-sidenav__header o-content-box u-fill">
+    {{#link-to 'index' class='c-sidenav__logo'}}Ember Data Twitch{{/link-to}}
+  </header>
+</section>
+
+<section class="c-sidenav__body-section">
+  <nav>
+    <ul class="c-sidenav__menu u-fill u-relative">
+      {{#each menuLinks as |menuLink|}}
+        {{menu-link-item class='c-sidenav__menu-link-item' routeName=menuLink.routeName title=menuLink.title isActive=(eq menuLink.routeName activeTopLevelRoute)}}
+      {{/each}}
+    </ul>
+  </nav>
+</section>

--- a/tests/dummy/app/templates/follows.hbs
+++ b/tests/dummy/app/templates/follows.hbs
@@ -1,0 +1,3 @@
+<h2>Follows</h2>
+
+{{outlet}}

--- a/tests/dummy/app/templates/games.hbs
+++ b/tests/dummy/app/templates/games.hbs
@@ -1,0 +1,3 @@
+<h2>Games</h2>
+
+{{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,2 @@
+<h2 class="homepage__heading u-align-center">Select a Resource to get started</h2>
+{{outlet}}

--- a/tests/dummy/app/templates/ingests.hbs
+++ b/tests/dummy/app/templates/ingests.hbs
@@ -1,0 +1,3 @@
+<h2>Ingests</h2>
+
+{{outlet}}

--- a/tests/dummy/app/templates/searches.hbs
+++ b/tests/dummy/app/templates/searches.hbs
@@ -1,0 +1,3 @@
+<h2>Searches</h2>
+
+{{outlet}}

--- a/tests/dummy/app/templates/streams.hbs
+++ b/tests/dummy/app/templates/streams.hbs
@@ -1,0 +1,3 @@
+<h2>Streams</h2>
+
+{{outlet}}

--- a/tests/dummy/app/templates/subscriptions.hbs
+++ b/tests/dummy/app/templates/subscriptions.hbs
@@ -1,0 +1,3 @@
+<h2>Subscriptions</h2>
+
+{{outlet}}

--- a/tests/dummy/app/templates/teams.hbs
+++ b/tests/dummy/app/templates/teams.hbs
@@ -1,0 +1,3 @@
+<h2>Teams</h2>
+
+{{outlet}}

--- a/tests/dummy/app/templates/users.hbs
+++ b/tests/dummy/app/templates/users.hbs
@@ -1,0 +1,3 @@
+<h2>Users</h2>
+
+{{outlet}}

--- a/tests/dummy/app/templates/videos.hbs
+++ b/tests/dummy/app/templates/videos.hbs
@@ -1,0 +1,9 @@
+<h2>Videos</h2>
+
+<ul>
+  {{#each model as |videos|}}
+    <li>video.title</li>
+  {{/each}}
+</ul>
+
+{{outlet}}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,8 +16,16 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+    },
+
+    twitch: {
+      redirectURI: 'http://localhost:4233/twitch-auth',
+      clientId: process.env.TWITCH_CLIENT_ID,
+      responseType: 'token'
     }
   };
+
+
 
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
@@ -40,8 +48,7 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     ENV.locationType = 'hash';
-    ENV.baseURL = '/ember-data-twitch/';
-
+    ENV.rootURL = '/ember-data-twitch/';
   }
 
   return ENV;

--- a/tests/unit/models/twitch-block-test.js
+++ b/tests/unit/models/twitch-block-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-block', 'Unit | Model | twitch block', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/twitch-channel-feed-test.js
+++ b/tests/unit/models/twitch-channel-feed-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-channel-feed', 'Unit | Model | twitch channel feed', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/twitch-channel-test.js
+++ b/tests/unit/models/twitch-channel-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-channel', 'Unit | Model | twitch channel', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/twitch-chat-test.js
+++ b/tests/unit/models/twitch-chat-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-chat', 'Unit | Model | twitch chat', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/twitch-follow-test.js
+++ b/tests/unit/models/twitch-follow-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-follow', 'Unit | Model | twitch follow', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/twitch-game-test.js
+++ b/tests/unit/models/twitch-game-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-game', 'Unit | Model | twitch game', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/twitch-ingest-test.js
+++ b/tests/unit/models/twitch-ingest-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-ingest', 'Unit | Model | twitch ingest', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/twitch-stream-test.js
+++ b/tests/unit/models/twitch-stream-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-stream', 'Unit | Model | twitch stream', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/twitch-subscription-test.js
+++ b/tests/unit/models/twitch-subscription-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-subscription', 'Unit | Model | twitch subscription', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/twitch-team-test.js
+++ b/tests/unit/models/twitch-team-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-team', 'Unit | Model | twitch team', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/twitch-user-test.js
+++ b/tests/unit/models/twitch-user-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-user', 'Unit | Model | twitch user', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/models/twitch-video-test.js
+++ b/tests/unit/models/twitch-video-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-video', 'Unit | Model | twitch video', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});


### PR DESCRIPTION
This PR addresses part of #17 -- mocking out a basic skeleton for adapters, serializers, models, and then laying out a dummy app with matching routes (and some style polish). 

Future improvements in this area include demoing how [auth'ed requests might be handled](https://github.com/elwayman02/ember-data-twitch/issues/20), and also giving the UI some nice responsive touches -- especially in terms of viewing routes form the sidenav.
