### PR TITLE
update to ember-data@2.8.0-beta.1 and change root adapter hooks appro…

### DIFF
--- a/addon/adapters/twitch.js
+++ b/addon/adapters/twitch.js
@@ -5,11 +5,23 @@ export default JSONAPIAdapter.extend({
   namespace: 'kraken',
   dataType: 'jsonp',
 
+
+  dataForRequest() {
+    const data = this._super(...arguments);
+    return data || {};
+  },
+
+  /**
+   * Currently, `ajaxOptions` is still the only place to alter
+   * the `dataType` request parameter
+   * @see: https://github.com/emberjs/data/pull/4357
+   */
   ajaxOptions() {
-    let hash = this._super.call(this, ...arguments);
-    hash.data = hash.data || {};
+    const hash = this._super(...arguments);
+
     hash.dataType = this.get('dataType');
     hash.traditional = true;
+
     return hash;
   }
 });

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-data": "^2.7.0"
+    "ember-data": "2.8.0-beta.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
This PR closes #22.

But there _are_ still a few things to be mindful of going forward.

[`ember-data` still lacks a way to change a few parameters on the ajax options hash](https://github.com/emberjs/data/pull/4357) -- in our current case, `dataType` and `traditional` -- outside of continuing to override `ajaxOptions` directly. I did move our interaction with the `data` parameter into [dataForRequest](http://emberjs.com/api/data/classes/DS.RESTAdapter.html#method_dataForRequest), and so as we override more functionality going forward, we'll just need to be considerate of [where to place what](http://emberjs.com/blog/2016/07/25/ember-data-2-7-released.html#toc_code-ds-improved-ajax-code-a-href-https-github-com-emberjs-data-pull-3099-3099-a).
