### PR TITLE
Remove setting `traditional` param on ajax hash

### DIFF
--- a/addon/adapters/twitch.js
+++ b/addon/adapters/twitch.js
@@ -18,9 +18,7 @@ export default JSONAPIAdapter.extend({
    */
   ajaxOptions() {
     const hash = this._super(...arguments);
-
     hash.dataType = this.get('dataType');
-    hash.traditional = true;
 
     return hash;
   }


### PR DESCRIPTION
This change removes the setting of the [`traditional` param](http://api.jquery.com/jQuery.param/) on our adapter's `ajax` hash, after establishing with @elwayman02 that we probably don't have a use case for it atm. ([This SO thread](http://stackoverflow.com/questions/5497093/what-is-traditional-style-of-param-serialization-in-jquery) provides some great insight, but essentially, we'd use it if we were dealing with arrays that had to be split out separately in our adapter's query params.)

This is a super-small change, but I wanted to document it with a PR in case we needed to revisit the issue -- or something related to it -- later 😄.
