### PR TITLE
Add initial adapters/serializers for models and  ensure correct pathForType

### DIFF
--- a/addon/adapters/twitch-block.js
+++ b/addon/adapters/twitch-block.js
@@ -1,0 +1,4 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({
+});

--- a/addon/adapters/twitch-channel-feed.js
+++ b/addon/adapters/twitch-channel-feed.js
@@ -1,0 +1,8 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({
+
+  pathForType(/* modelName */) {
+    return 'feed';
+  }
+});

--- a/addon/adapters/twitch-channel-feed.js
+++ b/addon/adapters/twitch-channel-feed.js
@@ -1,8 +1,10 @@
 import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
 
+
 export default TwitchAdapter.extend({
 
   pathForType(/* modelName */) {
     return 'feed';
   }
+
 });

--- a/addon/adapters/twitch-channel.js
+++ b/addon/adapters/twitch-channel.js
@@ -1,0 +1,4 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({
+});

--- a/addon/adapters/twitch-chat.js
+++ b/addon/adapters/twitch-chat.js
@@ -1,8 +1,5 @@
 import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
 
 export default TwitchAdapter.extend({
-
-  pathForType(/* modelName */) {
-    return 'chat';
-  }
+  pluralizePath: false
 });

--- a/addon/adapters/twitch-chat.js
+++ b/addon/adapters/twitch-chat.js
@@ -1,0 +1,8 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({
+
+  pathForType(/* modelName */) {
+    return 'chat';
+  }
+});

--- a/addon/adapters/twitch-follow.js
+++ b/addon/adapters/twitch-follow.js
@@ -1,0 +1,4 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({
+});

--- a/addon/adapters/twitch-game.js
+++ b/addon/adapters/twitch-game.js
@@ -1,0 +1,3 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({});

--- a/addon/adapters/twitch-ingest.js
+++ b/addon/adapters/twitch-ingest.js
@@ -1,0 +1,4 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({
+});

--- a/addon/adapters/twitch-stream.js
+++ b/addon/adapters/twitch-stream.js
@@ -1,0 +1,4 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({
+});

--- a/addon/adapters/twitch-subscription.js
+++ b/addon/adapters/twitch-subscription.js
@@ -1,0 +1,4 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({
+});

--- a/addon/adapters/twitch-team.js
+++ b/addon/adapters/twitch-team.js
@@ -1,0 +1,4 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({
+});

--- a/addon/adapters/twitch-user.js
+++ b/addon/adapters/twitch-user.js
@@ -1,0 +1,4 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({
+});

--- a/addon/adapters/twitch-video.js
+++ b/addon/adapters/twitch-video.js
@@ -1,0 +1,4 @@
+import TwitchAdapter from 'ember-data-twitch/adapters/twitch';
+
+export default TwitchAdapter.extend({
+});

--- a/addon/adapters/twitch.js
+++ b/addon/adapters/twitch.js
@@ -9,16 +9,19 @@ export default JSONAPIAdapter.extend({
   host: 'https://api.twitch.tv',
   namespace: 'kraken',
   dataType: 'jsonp',
+  pluralizePath: true,
 
   /**
-   * Determines a path fo a given type
+   * Determines a path for a given type
    *
-   * By default, we'll aim to return camelized/plurailzed forms of the model name,
+   * By default, we'll aim to return camelized, plurailzed forms of the model name,
    * as that's currently the Twitch API's most common pattern. Some resources differ,
-   * however, and these cases will be handled by local overrides.
+   * however, and these cases can be handled by local overrides.
    */
   pathForType: function(modelName) {
-    return camelize(inflector.pluralize(modelName.replace('twitch-', '')));
+    const baseName = modelName.replace('twitch-', '');
+
+    return this.get('pluralizePath') ? camelize(inflector.pluralize(baseName)) : camelize(baseName);
   },
 
 

--- a/addon/adapters/twitch.js
+++ b/addon/adapters/twitch.js
@@ -1,9 +1,25 @@
 import JSONAPIAdapter from 'ember-data/adapters/json-api';
+import Inflector from 'ember-inflector';
+import { camelize } from 'ember-string';
+
+const { inflector } = Inflector;
+
 
 export default JSONAPIAdapter.extend({
   host: 'https://api.twitch.tv',
   namespace: 'kraken',
   dataType: 'jsonp',
+
+  /**
+   * Determines a path fo a given type
+   *
+   * By default, we'll aim to return camelized/plurailzed forms of the model name,
+   * as that's currently the Twitch API's most common pattern. Some resources differ,
+   * however, and these cases will be handled by local overrides.
+   */
+  pathForType: function(modelName) {
+    return camelize(inflector.pluralize(modelName.replace('twitch-', '')));
+  },
 
 
   dataForRequest() {

--- a/addon/serializers/twitch-block.js
+++ b/addon/serializers/twitch-block.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch-channel-feed.js
+++ b/addon/serializers/twitch-channel-feed.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch-channel.js
+++ b/addon/serializers/twitch-channel.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch-chat.js
+++ b/addon/serializers/twitch-chat.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch-follow.js
+++ b/addon/serializers/twitch-follow.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch-game.js
+++ b/addon/serializers/twitch-game.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch-ingest.js
+++ b/addon/serializers/twitch-ingest.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch-stream.js
+++ b/addon/serializers/twitch-stream.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch-subscription.js
+++ b/addon/serializers/twitch-subscription.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch-team.js
+++ b/addon/serializers/twitch-team.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch-user.js
+++ b/addon/serializers/twitch-user.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch-video.js
+++ b/addon/serializers/twitch-video.js
@@ -1,0 +1,4 @@
+import TwitchSerializer from 'ember-data-twitch/serializers/twitch';
+
+export default TwitchSerializer.extend({
+});

--- a/addon/serializers/twitch.js
+++ b/addon/serializers/twitch.js
@@ -1,4 +1,5 @@
 import JSONAPISerializer from 'ember-data/serializers/json-api';
 
 export default JSONAPISerializer.extend({
+
 });

--- a/app/adapters/twitch-block.js
+++ b/app/adapters/twitch-block.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-block';

--- a/app/adapters/twitch-channel-feed.js
+++ b/app/adapters/twitch-channel-feed.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-channel-feed';

--- a/app/adapters/twitch-channel.js
+++ b/app/adapters/twitch-channel.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-channel';

--- a/app/adapters/twitch-chat.js
+++ b/app/adapters/twitch-chat.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-chat';

--- a/app/adapters/twitch-follow.js
+++ b/app/adapters/twitch-follow.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-follow';

--- a/app/adapters/twitch-game.js
+++ b/app/adapters/twitch-game.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-game';

--- a/app/adapters/twitch-ingest.js
+++ b/app/adapters/twitch-ingest.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-ingest';

--- a/app/adapters/twitch-stream.js
+++ b/app/adapters/twitch-stream.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-stream';

--- a/app/adapters/twitch-subscription.js
+++ b/app/adapters/twitch-subscription.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-subscription';

--- a/app/adapters/twitch-team.js
+++ b/app/adapters/twitch-team.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-team';

--- a/app/adapters/twitch-user.js
+++ b/app/adapters/twitch-user.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-user';

--- a/app/adapters/twitch-video.js
+++ b/app/adapters/twitch-video.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/adapters/twitch-video';

--- a/app/serializers/twitch-block.js
+++ b/app/serializers/twitch-block.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-block';

--- a/app/serializers/twitch-channel-feed.js
+++ b/app/serializers/twitch-channel-feed.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-channel-feed';

--- a/app/serializers/twitch-channel.js
+++ b/app/serializers/twitch-channel.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-channel';

--- a/app/serializers/twitch-chat.js
+++ b/app/serializers/twitch-chat.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-chat';

--- a/app/serializers/twitch-follow.js
+++ b/app/serializers/twitch-follow.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-follow';

--- a/app/serializers/twitch-game.js
+++ b/app/serializers/twitch-game.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-game';

--- a/app/serializers/twitch-ingest.js
+++ b/app/serializers/twitch-ingest.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-ingest';

--- a/app/serializers/twitch-stream.js
+++ b/app/serializers/twitch-stream.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-stream';

--- a/app/serializers/twitch-subscription.js
+++ b/app/serializers/twitch-subscription.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-subscription';

--- a/app/serializers/twitch-team.js
+++ b/app/serializers/twitch-team.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-team';

--- a/app/serializers/twitch-user.js
+++ b/app/serializers/twitch-user.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-user';

--- a/app/serializers/twitch-video.js
+++ b/app/serializers/twitch-video.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-data-twitch/serializers/twitch-video';

--- a/tests/unit/adapters/twitch-block-test.js
+++ b/tests/unit/adapters/twitch-block-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let actual, expected;
+
+moduleFor('adapter:twitch-block', 'Unit | Adapter | twitch block', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-block';
+
+  expected = 'blocks';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/adapters/twitch-channel-feed-test.js
+++ b/tests/unit/adapters/twitch-channel-feed-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let actual, expected;
+
+moduleFor('adapter:twitch-channel-feed', 'Unit | Adapter | twitch channel feed', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-channel-feed';
+
+  expected = 'feed';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/adapters/twitch-channel-test.js
+++ b/tests/unit/adapters/twitch-channel-test.js
@@ -1,0 +1,20 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let actual, expected;
+
+moduleFor('adapter:twitch-channel', 'Unit | Adapter | twitch channel', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+// Replace this with your real tests.
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-channel';
+
+  expected = 'channels';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/adapters/twitch-chat-test.js
+++ b/tests/unit/adapters/twitch-chat-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let actual, expected;
+
+moduleFor('adapter:twitch-chat', 'Unit | Adapter | twitch chat', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-chat';
+
+  expected = 'chat';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/adapters/twitch-follow-test.js
+++ b/tests/unit/adapters/twitch-follow-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let expected, actual;
+
+moduleFor('adapter:twitch-follow', 'Unit | Adapter | twitch follow', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-follow';
+
+  expected = 'follows';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/adapters/twitch-game-test.js
+++ b/tests/unit/adapters/twitch-game-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let actual, expected;
+
+moduleFor('adapter:twitch-game', 'Unit | Adapter | twitch game', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-game';
+
+  expected = 'games';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/adapters/twitch-ingest-test.js
+++ b/tests/unit/adapters/twitch-ingest-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let actual, expected;
+
+moduleFor('adapter:twitch-ingest', 'Unit | Adapter | twitch ingest', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-ingest';
+
+  expected = 'ingests';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/adapters/twitch-stream-test.js
+++ b/tests/unit/adapters/twitch-stream-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let expected, actual;
+
+moduleFor('adapter:twitch-stream', 'Unit | Adapter | twitch stream', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-stream';
+
+  expected = 'streams';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/adapters/twitch-subscription-test.js
+++ b/tests/unit/adapters/twitch-subscription-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let actual, expected;
+
+moduleFor('adapter:twitch-subscription', 'Unit | Adapter | twitch subscription', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-subscription';
+
+  expected = 'subscriptions';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/adapters/twitch-team-test.js
+++ b/tests/unit/adapters/twitch-team-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let actual, expected;
+
+moduleFor('adapter:twitch-team', 'Unit | Adapter | twitch team', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-team';
+
+  expected = 'teams';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/adapters/twitch-user-test.js
+++ b/tests/unit/adapters/twitch-user-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let actual, expected;
+
+moduleFor('adapter:twitch-user', 'Unit | Adapter | twitch user', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-user';
+
+  expected = 'users';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/adapters/twitch-video-test.js
+++ b/tests/unit/adapters/twitch-video-test.js
@@ -1,0 +1,19 @@
+import { moduleFor, test } from 'ember-qunit';
+
+
+let actual, expected;
+
+moduleFor('adapter:twitch-video', 'Unit | Adapter | twitch video', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('`pathForType` computes the correct Twitch API URL for the `modelName`', function (assert) {
+  const adapter = this.subject();
+  const modelName = 'twitch-video';
+
+  expected = 'videos';
+  actual = adapter.pathForType(modelName);
+
+  assert.equal(actual, expected, `path for "${modelName} resolves to ${expected}`);
+});

--- a/tests/unit/serializers/twitch-block-test.js
+++ b/tests/unit/serializers/twitch-block-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-block', 'Unit | Serializer | twitch block', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-block']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/twitch-channel-feed-test.js
+++ b/tests/unit/serializers/twitch-channel-feed-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-channel-feed', 'Unit | Serializer | twitch channel feed', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-channel-feed']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/twitch-channel-test.js
+++ b/tests/unit/serializers/twitch-channel-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-channel', 'Unit | Serializer | twitch channel', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-channel']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/twitch-chat-test.js
+++ b/tests/unit/serializers/twitch-chat-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-chat', 'Unit | Serializer | twitch chat', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-chat']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/twitch-follow-test.js
+++ b/tests/unit/serializers/twitch-follow-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-follow', 'Unit | Serializer | twitch follow', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-follow']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/twitch-game-test.js
+++ b/tests/unit/serializers/twitch-game-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-game', 'Unit | Serializer | twitch game', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-game']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/twitch-ingest-test.js
+++ b/tests/unit/serializers/twitch-ingest-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-ingest', 'Unit | Serializer | twitch ingest', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-ingest']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/twitch-stream-test.js
+++ b/tests/unit/serializers/twitch-stream-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-stream', 'Unit | Serializer | twitch stream', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-stream']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/twitch-subscription-test.js
+++ b/tests/unit/serializers/twitch-subscription-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-subscription', 'Unit | Serializer | twitch subscription', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-subscription']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/twitch-team-test.js
+++ b/tests/unit/serializers/twitch-team-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-team', 'Unit | Serializer | twitch team', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-team']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/twitch-user-test.js
+++ b/tests/unit/serializers/twitch-user-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-user', 'Unit | Serializer | twitch user', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-user']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});

--- a/tests/unit/serializers/twitch-video-test.js
+++ b/tests/unit/serializers/twitch-video-test.js
@@ -1,0 +1,15 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('twitch-video', 'Unit | Serializer | twitch video', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:twitch-video']
+});
+
+// Replace this with your real tests.
+test('it serializes records', function(assert) {
+  let record = this.subject();
+
+  let serializedRecord = record.serialize();
+
+  assert.ok(serializedRecord);
+});


### PR DESCRIPTION
This PR adds a minor improvement to our base setup by defining the root adapter's `pathForType`, and then overriding where needed. I commented more thuroughly on my current logic [here](https://github.com/elwayman02/ember-data-twitch/compare/define-path-for-type?expand=1#diff-2b34f2ed22410a74d14d7d7d7292b3b9R16).

Also, since i was giving care to each resource, I went ahead and generated its basic adapter and serializer, and implemented a local test for the result of `pathForType` (hence the 74 files 😄 ).
