### PR TITLE
Update to ember-cli-shims 0.1.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-data-twitch",
   "dependencies": {
     "ember": "~2.7.0",
-    "ember-cli-shims": "0.1.1",
+    "ember-cli-shims": "0.1.3",
     "ember-qunit-notifications": "0.1.0"
   }
 }


### PR DESCRIPTION
It turns out that our current 0.1.1 version of `ember-cli-shims` [doesn't include `getOwner`](https://github.com/cibernox/ember-power-select/issues/612). This PR gets us up to the latest, which does. 
