### PR TITLE
Abstract client id initialization into a helper function and add tests

### DIFF
--- a/addon/adapters/twitch.js
+++ b/addon/adapters/twitch.js
@@ -14,14 +14,7 @@ export default JSONAPIAdapter.extend({
   init() {
     this._super(...arguments);
 
-    this.clientID = this.clientID || TwitchConfig.clientID;
-
-    if (!this.clientID) {
-      throw new Error(
-        'This adapter requires a `clientID` to be set before using the Twitch API ' +
-        'You can define a root `clientID` in the `ENV[\'ember-data-twitch\']` hash of `config/environment.js`'
-      );
-    }
+    this._initHeaders();
   },
 
   headers: {
@@ -58,5 +51,18 @@ export default JSONAPIAdapter.extend({
     hash.dataType = this.get('dataType');
 
     return hash;
+  },
+
+  _initHeaders() {
+    this.clientID = this.clientID ? this.clientID : TwitchConfig.clientID;
+
+    if (!this.clientID) {
+      throw new Error(
+        'This adapter requires a `clientID` to be set before using the Twitch API ' +
+        'You can define a root `clientID` in the `ENV[\'ember-data-twitch\']` hash of `config/environment.js`'
+      );
+    }
+
+    this.headers['Client-ID'] = this.clientID;
   }
 });

--- a/tests/unit/adapters/twitch-test.js
+++ b/tests/unit/adapters/twitch-test.js
@@ -1,16 +1,44 @@
 import { moduleFor, test } from 'ember-qunit';
-import initTwitchConfig from '../../helpers/init-twitch-config';
+import TwitchConfig from 'ember-data-twitch/configuration';
 
-moduleFor('adapter:twitch', 'Unit | Adapter | twitch', {
+let adapter;
+let message;
+let TEST_CLIENT_ID = 'test_client_id';
+
+moduleFor('adapter:twitch', 'Unit | Adapter | twitch root', {
   // Specify the other units that are required for this test.
-  // needs: ['serializer:foo'],
-  beforeEach() {
-    initTwitchConfig();
-  }
+  // needs: ['serializer:foo']
 });
 
-// Replace this with your real tests.
-test('it exists', function(assert) {
-  let adapter = this.subject();
-  assert.ok(adapter);
+test('setting a `clientID` during init', function(assert) {
+  message = 'clientID is read from the adapter';
+  TwitchConfig.load({ clientID: '' });
+  adapter = this.subject({ clientID: TEST_CLIENT_ID });
+  adapter.init();
+
+  assert.equal(adapter.clientID, TEST_CLIENT_ID, message);
+
+  message = 'clientID is read from the addon config if not found on the adapter';
+  adapter.set('clientID', '');
+  TwitchConfig.load({ clientID: TEST_CLIENT_ID });
+  adapter.init();
+
+  assert.equal(adapter.clientID, TEST_CLIENT_ID, message);
+
+  message = 'an error is thrown when no clientID is set';
+  TwitchConfig.load({ clientID: '' });
+  adapter.set('clientID', '');
+
+  assert.throws(
+    () => { adapter.init(); },
+    message
+  );
+});
+
+test('headers', function(assert) {
+  message = 'The `Client-ID` header is set from the `clientID` property';
+  TwitchConfig.load({ clientID: TEST_CLIENT_ID });
+  adapter = this.subject();
+
+  assert.equal(adapter.headers['Client-ID'], TEST_CLIENT_ID, message);
 });


### PR DESCRIPTION
@elwayman02 Sorry, I didn't realize it until just after merging #53, but the logic that it added for clientID initialization should really be abstracted out of the `init` hook.

I also added a few unit tests to cover what's going on there.
