### PR TITLE
Update to ember-cli-eslint 3.x

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,13 @@
 module.exports = {
-  extends: './node_modules/ember-cli-eslint/coding-standard/ember-application.js'
+  root: true,
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  },
+  extends: 'eslint:recommended',
+  env: {
+    'browser': true
+  },
+  rules: {
+  }
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-dotenv": "1.2.0",
-    "ember-cli-eslint": "1.8.0",
+    "ember-cli-eslint": "3.0.0",
     "ember-cli-github-pages": "0.1.2",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,3 +1,5 @@
 module.exports = {
-  extends: '../node_modules/ember-cli-eslint/coding-standard/ember-testing.js'
+  env: {
+    'embertest': true
+  }
 };


### PR DESCRIPTION
This PR replaces #45. We should be set up just fine to use `ember-cli-eslint` 3.x -- there's just a minor breaking change of it [not having a default standard to extend from any more](https://github.com/elwayman02/ember-data-twitch/compare/update-to-eslint-3.x?expand=1#diff-e4403a877d80de653400d88d85e4801aL2).  

The settings that _were_ there are now simply generated in the root `.eslintrc` and `tests/.eslintrc` files themselves, and so this PR wouldn't change anything that we already had in place.
