### PR TITLE
Integrate ember-cli-code-coverage and report to code-climate in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log
 .env
+.vscode
+.vscodeignore
+/typings/*
+jsconfig.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "4"
 
 sudo: false
-
 cache:
   directories:
     - node_modules
@@ -33,6 +32,8 @@ install:
   - bower install
 
 script:
-  # Usually, it's ok to finish the test scenario without reverting
-  #  to the addon's original dependency state, skipping "cleanup".
-  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+  - npm run test:coverage:ci
+
+after_script:
+  - npm install codeclimate-test-reporter
+  - cat coverage/lcov.info | node_modules/.bin/codeclimate-test-reporter

--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ How this value is retrieved and stored within your application is up to you, but
 for good security practice, we recommend making use of [`ember-cli-dotenv`](https://github.com/fivetanley/ember-cli-dotenv).
 
 
-## Contributing
-
-This section outlines the details of collaborating on this Ember addon.
+## Collaborating
 
 ### Installation
 
@@ -50,16 +48,27 @@ Once you have a client key, create a `.env` file at the root of your project and
 
 `TWITCH_CLIENT_ID=yourtwitchclientid`
 
-### Running
+### Running the Dummy App
 
 * `ember serve`
-* Visit your app at [http://localhost:4200](http://localhost:4200).
+* Visit your app at [http://localhost:4233](http://localhost:4233).
 
 ### Running Tests
 
 * `npm test` (Runs `ember try:each` to test your addon against multiple Ember versions)
 * `ember test`
 * `ember test --server`
+
+#### Running Tests with Code Coverage
+
+This project uses [`ember-cli-code-coverage`](https://github.com/kategengler/ember-cli-code-coverage) to generate test coverage reports.
+You can run it with the following command:
+
+```sh
+npm run test:coverage
+```
+
+From there, to view the results, simply open up the files generated inside of the `coverage` directory.
 
 ### Building
 

--- a/config/coverage.js
+++ b/config/coverage.js
@@ -1,0 +1,8 @@
+/* global module */
+
+/**
+ * Configuration for `ember-cli-code-coverage`
+ */
+ module.exports = {
+   reporters: ['lcov', 'html']
+ };

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* global module */
 module.exports = {
   scenarios: [
     {

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,4 @@
-/*jshint node:true*/
-'use strict';
-
+/* global module */
 module.exports = function(/* environment, appConfig */) {
   return { };
 };

--- a/config/release.js
+++ b/config/release.js
@@ -1,4 +1,4 @@
-/* jshint node:true */
+/* global module */
 
 // For details on each option run `ember help release`
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "build": "ember build",
     "deploy": "ember github-pages:commit --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\"; git push; git checkout -",
     "start": "ember server",
-    "test": "ember try:each"
+    "test": "ember try:each",
+    "test:coverage": "cross-env COVERAGE=true ember test",
+    "test:coverage:serve": "cross-env COVERAGE=true ember test --serve",
+    "test:coverage:ci": "ember try:one $EMBER_TRY_SCENARIO && npm run test:coverage"
   },
   "repository": "https://github.com/elwayman02/ember-data-twitch",
   "engines": {
@@ -20,9 +23,11 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "cross-env": "^3.1.3",
     "ember-ajax": "^2.0.1",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^2.0.0",
+    "ember-cli-code-coverage": "0.3.4",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-dotenv": "1.2.0",
     "ember-cli-eslint": "3.0.0",


### PR DESCRIPTION
This PR addresses #1 by configuring `ember-cli-code-coverage` and wiring up `.travis.yml` to report coverage results to `code-climate`. 

A future task that I'm _really_ curious to explore is getting a build to fail according to a certain coverage threshold, but right now, at least with our current tools, this seems to be a [work in progress](https://github.com/kategengler/ember-cli-code-coverage/issues/23).
